### PR TITLE
K nearest neighbour is not always filled completely. 

### DIFF
--- a/Example/Tests/KDTreeTest.swift
+++ b/Example/Tests/KDTreeTest.swift
@@ -1,0 +1,15 @@
+import XCTest
+import KDTree
+
+class KDTreeTest: XCTestCase {
+    
+    func testNearestK_LookUpDistantSubTreesIfResultArrayNotFull()
+    {
+        let points = [CGPoint(x: 1,y: 1), CGPoint(x: 0,y: 1), CGPoint(x: -1,y: 1)]
+        let tree = KDTree(values: points)
+        let n = tree.nearestK(3, toElement: CGPoint(x: 1, y: 1))
+        
+        XCTAssertEqual(n, [CGPoint(x: 1,y: 1), CGPoint(x: 0,y: 1), CGPoint(x: -1,y: 1)])
+    }
+    
+}

--- a/Pod/Classes/KDTree+NearestNeighbour.swift
+++ b/Pod/Classes/KDTree+NearestNeighbour.swift
@@ -124,7 +124,7 @@ extension KDTree {
 
             //if the bestDistance so far intersects the hyperplane at the other side of this value
             //there could be points in the other subtree
-            if dimensionDifference*dimensionDifference < bestValues.biggestDistance {
+            if dimensionDifference*dimensionDifference < bestValues.biggestDistance || !bestValues.full {
                 let otherSubtree = isLeftOfValue ? right : left
                 otherSubtree.nearestK(toElement: searchElement, bestValues: &bestValues)
             }


### PR DESCRIPTION
Under certain conditions (see test case) the algorithm does not look for more points in a more distant sub-tree. This can lead to not finding less k neighbours in a tree that has more than k nodes.

Sorry for not putting the test case in the QuickSpec. I had trouble with getting the cocoa pods stuff to work and decided to do a normal test case for time reasons.