### PR TITLE
Minor changes to median splitting 

### DIFF
--- a/Example/KDTree/Images.xcassets/AppIcon.appiconset/Contents.json
+++ b/Example/KDTree/Images.xcassets/AppIcon.appiconset/Contents.json
@@ -89,6 +89,11 @@
       "idiom" : "ipad",
       "filename" : "83.5*2.png",
       "scale" : "2x"
+    },
+    {
+      "idiom" : "ios-marketing",
+      "size" : "1024x1024",
+      "scale" : "1x"
     }
   ],
   "info" : {

--- a/Example/Tests/GridTest.swift
+++ b/Example/Tests/GridTest.swift
@@ -61,7 +61,19 @@ class GridTest: XCTestCase {
         
         XCTAssertEqual(0, containedPoints, "All original points should be contained in the tree")
     }
+  
+  func testPointsDeleted() {
     
+    var pointsNotDeleted = 0
+    for point in points {
+      if tree.removing(point).count == tree.count {
+        pointsNotDeleted += 1
+      }
+    }
+    
+    XCTAssertEqual(0, pointsNotDeleted, "All original points should be be deleted in the tree")
+  }
+  
     func testSelfShouldBeNearest() {
         var notNearestCount = 0
 

--- a/Sources/KDTree.swift
+++ b/Sources/KDTree.swift
@@ -31,7 +31,16 @@ public enum KDTree<Element: KDTreePoint> {
             let sortedValues = values.sorted { (a, b) -> Bool in
                 return a.kdDimension(currentSplittingDimension) < b.kdDimension(currentSplittingDimension)
             }
-            let median = sortedValues.count / 2
+          
+            var median = sortedValues.count / 2
+            let medianValue = sortedValues[median].kdDimension(currentSplittingDimension)
+          
+            //Ensure left subtree contains currentSplittingDimension-coordinate strictly less than its parent node
+            //Needed for 'contains' and 'removing' method.
+            while median >= 1 && abs(sortedValues[median-1].kdDimension(currentSplittingDimension) - medianValue) < Double.ulpOfOne {
+              median -= 1
+            }
+          
             let leftTree = KDTree(values: Array(sortedValues[0..<median]), depth: depth+1)
             let rightTree = KDTree(values: Array(sortedValues[median+1..<sortedValues.count]), depth: depth+1)
             
@@ -85,8 +94,6 @@ public enum KDTree<Element: KDTreePoint> {
                 let nodeDist = nodeValue.kdDimension(dim)
                 if valueDist < nodeDist {
                     return left.contains(value)
-                } else if abs(valueDist - nodeDist) < Double.ulpOfOne {
-                    return left.contains(value) || right.contains(value)
                 } else {
                     return right.contains(value)
                 }


### PR DESCRIPTION
Ensure left subtree contains currentSplittingDimension-coordinate strictly less than its parent node.
This fix is needed for 'contains' and 'removing' method.