### PR TITLE
Re-add test target

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -14,6 +14,11 @@ let package = Package(
         .target(
             name: "KDTree",
             path: "Sources"
+        ),
+        .testTarget(
+            name: "Tests",
+            dependencies: ["KDTree"],
+            path: "Tests"
         )
     ]
 )


### PR DESCRIPTION
Swift 4 doesn't have the automatic test target anymore. This adds it back in. (We should merge this before #31)