### PR TITLE
Update KDTree+NearestNeighbour.swift

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ It's also possible to use the KDTree to search for a range of values using:
 let pointsInRange: [CGPoint] = tree.elementsInRange([(0.2, 0.4), (0.45, 0.75)])
 ```
 
-One example is based on the [HYG Database](https://github.com/astronexus/HYG-Database/blob/master/README.md) of 120 thousend stars. Here we see a piece of the sky around 10h right ascension and 35° declination where the KDTree algorithm can be used to both get the stars in the area the iPhone screen is pointing at and also find the closest Star to a position the user is tapping via NN:
+One example is based on the [HYG Database](https://github.com/astronexus/HYG-Database/blob/master/README.md) of 120 thousand stars. Here we see a piece of the sky around 10h right ascension and 35° declination where the KDTree algorithm can be used to both get the stars in the area the iPhone screen is pointing at and also find the closest Star to a position the user is tapping via NN:
 
 <img src="https://raw.githubusercontent.com/Bersaelor/KDTree/master/Screenshots/starMap.png" width="621" />
 

--- a/Sources/KDTree+NearestNeighbour.swift
+++ b/Sources/KDTree+NearestNeighbour.swift
@@ -156,15 +156,15 @@ extension KDTree {
             let closerSubtree = isLeftOfValue ? left : right
             closerSubtree.allPoints(within: radius, of: searchElement, points: &points)
             
-            //check the nodes value
-            let currentDistance = value.squaredDistance(to: searchElement)
-            if currentDistance <= radius * radius {
-                points.append(value)
-            }
-            
             //if the radius so far intersects the hyperplane at the other side of this value
             //there could be points in the other subtree
-            if dimensionDifference < radius {
+            if abs(dimensionDifference) < radius {
+                //check the nodes value
+                let currentDistance = value.squaredDistance(to: searchElement)
+                if currentDistance <= radius * radius {
+                    points.append(value)
+                }
+                
                 let otherSubtree = isLeftOfValue ? right : left
                 otherSubtree.allPoints(within: radius, of: searchElement, points: &points)
             }

--- a/Sources/KDTree+NearestNeighbour.swift
+++ b/Sources/KDTree+NearestNeighbour.swift
@@ -156,7 +156,7 @@ extension KDTree {
             let closerSubtree = isLeftOfValue ? left : right
             closerSubtree.allPoints(within: radius, of: searchElement, points: &points)
             
-            //if the radius so far intersects the hyperplane at the other side of this value
+            //if the search radius intersects the hyperplane of this tree node
             //there could be points in the other subtree
             if abs(dimensionDifference) < radius {
                 //check the nodes value


### PR DESCRIPTION
We need to take the absolute value of the dimensionDifference to fairly compare it to the radius.

Also, I like checking the node value after we see if the radius intersects the hyperplain.

This build should pass with a small speedup to allPoints(within: of:)