### PR TITLE
Performance improvement

### DIFF
--- a/Sources/KDTree.swift
+++ b/Sources/KDTree.swift
@@ -47,30 +47,6 @@ extension KDTree {
         pointer.deallocate()
     }
     
-    public init(values: ArraySlice<Element>, depth: Int = 0) {
-
-        let count = values.count
-        
-        self = values.withUnsafeBufferPointer { bufferPointer in
-            guard let start = bufferPointer.baseAddress, count > 0 else {
-                return .leaf
-            }
-            
-            let pointer = UnsafeMutablePointer<Element>.allocate(capacity: count)
-            
-            defer {
-                // deallocate the pointer later
-                pointer.deallocate()
-            }
-            
-            // copy values from the array
-            pointer.initialize(from: start, count: count)
-            
-            return KDTree(values: pointer, startIndex: 0, endIndex: count, depth: depth)
-        }
-        
-    }
-    
     private init(values: UnsafeMutablePointer<Element>, startIndex: Int, endIndex: Int, depth: Int = 0) {
         guard endIndex > startIndex else {
             self = .leaf

--- a/Sources/KDTree.swift
+++ b/Sources/KDTree.swift
@@ -41,7 +41,7 @@ extension KDTree {
         // copy values from the array
         pointer.initialize(from: values, count: count)
         
-        self = KDTree(values: pointer, startIndex: 0, endIndex: count)
+        self = KDTree(values: pointer, startIndex: 0, endIndex: count, depth: depth)
         
         // deallocate the pointer
         pointer.deallocate()
@@ -66,7 +66,7 @@ extension KDTree {
             // copy values from the array
             pointer.initialize(from: start, count: count)
             
-            return KDTree(values: pointer, startIndex: 0, endIndex: count)
+            return KDTree(values: pointer, startIndex: 0, endIndex: count, depth: depth)
         }
         
     }


### PR DESCRIPTION
Use `UnsafeMutablePointer` instead of `ArraySlice` during `KDTree.init`.

Performance improvement of approximately 4x for tree build.

<img width="751" alt="Performance comparison Array vs UnsafeMutablePointer" src="https://user-images.githubusercontent.com/212052/65673666-8597d500-e04b-11e9-9136-6c36af16e6c9.png">
