### PR TITLE
Disable Codable/Encodable behaviour when using WebAssembly

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 
 .build
 /.previous-build
+.swiftpm
 
 # Carthage
 

--- a/Sources/KDTree+Codable.swift
+++ b/Sources/KDTree+Codable.swift
@@ -88,7 +88,7 @@ extension KDTree: Decodable where Element: Decodable {
         }
     }
 }
-
+#if !os(WASI)
 extension KDTree where Element: Encodable {
     
     public func save(to path: URL) throws {
@@ -112,3 +112,4 @@ extension KDTree where Element: Decodable {
 #endif
     }
 }
+#endif


### PR DESCRIPTION
### :tophat: What is the goal?

Provide support for WebAssembly builds 😃 

### How is it being implemented?

Thanks to the usage of the Swift Package manager this repository can be built as a WebAssembly binary. However, the codable behavior for the ``KDTree`` component is not supported by the Swift WebAssembly toolchain. As this behavior is not mandatory I've decided to add a C macro to disable this feature when we build the code for WASM. The list of available Foundation features WASM supports can be found [here](https://book.swiftwasm.org/getting-started/foundation.html).

I've also updated ``.gitignore`` file, but this is just a minor change 😃 

P.S: Thank you so much for this awesome library. I really appreciate the time and effort needed to make this an open-source project.